### PR TITLE
Enable multi-turn dialogue for Llama3

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -64,6 +64,8 @@ def main(
             completion = batch_completions[0]["generation"]
             print(new_text, end="", flush=True)
         print("\n\n==================================\n")
+        # 将本轮对话加入历史，便于多轮对话
+        model_prompter.update_template(completion)
 
 
 if __name__ == "__main__":

--- a/cli_llava.py
+++ b/cli_llava.py
@@ -119,6 +119,8 @@ def main(
             print(f"\033[91m{next_text}\033[0m", end="", flush=True)  # 红色文本
 
         console.print("\n[bold green]==================================[/bold green]\n")
+        # 更新模板以保存历史会话
+        model_prompter.update_template(completion)
 
 
 if __name__ == "__main__":

--- a/generate.py
+++ b/generate.py
@@ -100,6 +100,8 @@ def main(
         text_msg += new_text
 
     print("\n\n==================================\n")
+    # 记录对话结果，支持后续多轮对话
+    model_prompter.update_template(completion)
     print(
         f"Time for inference: {(end - start):.2f} sec, {count_tokens(text_msg, generator.tokenizer) / (end - start):.2f} tokens/sec"
     )

--- a/lite_llama/utils/prompt_templates.py
+++ b/lite_llama/utils/prompt_templates.py
@@ -192,7 +192,8 @@ class Llama3Prompter(BasePrompter):
     """
 
     def __init__(self):
-        system_inst = ""
+        # Llama3 对话格式不需要系统提示时，直接从 user 开始
+        system_inst = None
         role1 = "<|start_header_id|>user<|end_header_id|>\n\n"
         role2 = "<|start_header_id|>assistant<|end_header_id|>\n\n"
         sen_spliter = "<|eot_id|>"
@@ -201,6 +202,22 @@ class Llama3Prompter(BasePrompter):
         super().__init__(
             system_inst, role1, role2, sen_spliter, qa_spliter, colon=colon
         )
+
+    def update_template(self, outputs, chunk_prefilling: int = 0):
+        """Update template for multi-turn conversation."""
+        if chunk_prefilling:
+            self.template = self.role1 + "{prompt}" + self.sen_spliter + self.role2
+        else:
+            self.template = (
+                self.model_input
+                + outputs.strip()
+                + self.sen_spliter
+                + self.role1
+                + "{prompt}"
+                + self.sen_spliter
+                + self.role2
+            )
+        self.model_input = None
 
 
 class LlavaLlamaPrompter(BasePrompter):
@@ -238,6 +255,22 @@ class LlavaLlama3Prompter(BasePrompter):
         super().__init__(
             system_inst, role1, role2, sen_spliter, qa_spliter, colon=colon
         )
+
+    def update_template(self, outputs, chunk_prefilling: int = 0):
+        """Update template for multi-turn conversation with vision."""
+        if chunk_prefilling:
+            self.template = self.role1 + "{prompt}" + self.sen_spliter + self.role2
+        else:
+            self.template = (
+                self.model_input
+                + outputs.strip()
+                + self.sen_spliter
+                + self.role1
+                + "{prompt}"
+                + self.sen_spliter
+                + self.role2
+            )
+        self.model_input = None
 
 
 class Qwen2Prompter(BasePrompter):


### PR DESCRIPTION
## Summary
- support multi-turn updates in `Llama3Prompter` and `LlavaLlama3Prompter`
- keep conversation history in command line tools

## Testing
- `pytest -k prompt -q` *(fails: ModuleNotFoundError: No module named 'lite_llama.lite_llama')*

------
https://chatgpt.com/codex/tasks/task_e_683ffe0703088327970805f612759d96